### PR TITLE
Cannot have Is of 2 different types adjacent

### DIFF
--- a/2017/files/emerging.dev.conll
+++ b/2017/files/emerging.dev.conll
@@ -1671,7 +1671,7 @@ respawn	O
 
 Lil	B-person
 Sly-	I-person
-Turn	I-creative-work
+Turn	B-creative-work
 Up	I-creative-work
 Green	I-creative-work
 #	O


### PR DESCRIPTION
Found while training an NER tagger that validates IOB2 spans on dev/test sets.  Since results have been published on dataset as-is, not sure if this can/should be merged, but figured I'd open a PR just in case.